### PR TITLE
Add editor to make an existing project a basic generator

### DIFF
--- a/.atomist/editors/ConvertExistingProjectToGenerator.ts
+++ b/.atomist/editors/ConvertExistingProjectToGenerator.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EditProject } from '@atomist/rug/operations/ProjectEditor'
+import { Project, File } from '@atomist/rug/model/Core'
+import { Pattern } from '@atomist/rug/operations/RugOperation'
+import { Editor, Parameter, Tags } from '@atomist/rug/operations/Decorators'
+import { PathExpression, PathExpressionEngine, TreeNode, Match } from '@atomist/rug/tree/PathExpression'
+import { addAssertionsForAllFilesInProject } from './ProjectToGeneratorOperations'
+
+@Editor("ConvertExistingProjectToGenerator", "convert existing project to a Rug archive with a basic Generator")
+@Tags("rug", "atomist")
+class ConvertExistingProjectToGenerator implements EditProject {
+
+    @Parameter({
+        displayName: "Rug Archive Name",
+        description: "name of your new Rug Archive, typically the same as the repo name",
+        pattern: Pattern.project_name,
+        validInput: "a valid GitHub repo name containing only alphanumeric, ., -, and _ characters",
+        minLength: 1,
+        maxLength: 100
+    })
+    archive_name: string;
+
+    @Parameter({
+        displayName: "Rug Archive Group ID",
+        description: "Maven group identifier, often used to provide a namespace for your rugs, e.g., company-rugs, typically the GitHub owner",
+        pattern: Pattern.group_id,
+        validInput: "a valid Maven group ID, which starts with a letter, -, or _ and contains only alphanumeric, -, and _ characters and may having leading period separated identifiers starting with letters or underscores and containing only alphanumeric and _ characters",
+        minLength: 1,
+        maxLength: 100
+    })
+    group_id: string;
+
+    @Parameter({
+        displayName: "Rug Archive Version",
+        description: "initial version of the project, e.g., 1.2.3",
+        pattern: Pattern.semantic_version,
+        validInput: "a valid semantic version, http://semver.org",
+        minLength: 1,
+        maxLength: 100,
+        required: false,
+    })
+    version: string = "0.1.0";
+
+    @Parameter({
+        displayName: "Generator Name",
+        description: "name of generator to add to Rug archive project",
+        pattern: "^[A-Z][A-Za-z0-9]*$",
+        validInput: "a valid generator name starting with a capital letter and consisting of alphanumeric characters from one to 100 characters long",
+        minLength: 1,
+        maxLength: 100
+    })
+    generator_name: string;
+
+    @Parameter({
+        displayName: "Generator Description",
+        description: "description of generator to add to Rug archive project",
+        pattern: Pattern.any,
+        validInput: "a string between one and 100 characters",
+        minLength: 1,
+        maxLength: 100
+    })
+    description: string
+
+    edit(project: Project) {
+        if (project.fileExists(".atomist/manifest.yml")) {
+            return;
+        } 
+        project.editWith("ConvertExistingProjectToRugArchive", this);
+        project.editWith("AddTypeScript", {})
+        project.editWith("AddTypeScriptGenerator", this)
+
+        addAssertionsForAllFilesInProject(project, this.generator_name)
+    }
+}
+
+export const convertExistingProjectToGenerator = new ConvertExistingProjectToGenerator()

--- a/.atomist/editors/ProjectToGeneratorOperations.ts
+++ b/.atomist/editors/ProjectToGeneratorOperations.ts
@@ -20,17 +20,17 @@ import { PathExpression, PathExpressionEngine } from '@atomist/rug/tree/PathExpr
 export function addAssertionsForAllFilesInProject(project: Project, generatorName: string): void {
     let originalTestAssertionsString = "then\n  fileExists \"README.md\""
 
-    let testAssertionsString = project.files().reduce(function(acc, file) {
-      if (notACommonPeripheralArtifact(file)) {
-          if(acc === "then") {
-            acc +=  "\n  ";
-          } else {
-            acc +=  "\n    and ";
-          }
-          acc += `fileExists \"{file.path()}\"`;
-      }
-      return acc;
-    },"then")
+    let testAssertionsString = project.files().reduce(function (acc, file) {
+        if (notACommonPeripheralArtifact(file)) {
+            if (acc === "then") {
+                acc += "\n  ";
+            } else {
+                acc += "\n    and ";
+            }
+            acc += `fileExists "${file.path()}"`;
+        }
+        return acc;
+    }, "then")
 
     let eng: PathExpressionEngine = project.context().pathExpressionEngine();
     let testPathExpression = new PathExpression<Project, File>("/*[@name='.atomist']/tests/*[@name='" + generatorName + ".rt']");
@@ -40,7 +40,7 @@ export function addAssertionsForAllFilesInProject(project: Project, generatorNam
 
 function notACommonPeripheralArtifact(file: File): boolean {
     return (file.path().search("node_modules") < 0) &&
-           (file.path().search(".idea") < 0) && 
-           (file.path().search("target") < 0) &&
-           (file.path().search(".atomist") < 0)
+        (file.path().search(".idea") < 0) &&
+        (file.path().search("target") < 0) &&
+        (file.path().search(".atomist") < 0)
 }

--- a/.atomist/editors/ProjectToGeneratorOperations.ts
+++ b/.atomist/editors/ProjectToGeneratorOperations.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Project, File } from '@atomist/rug/model/Core'
+import { PathExpression, PathExpressionEngine } from '@atomist/rug/tree/PathExpression'
+
+export function addAssertionsForAllFilesInProject(project: Project, generatorName: string): void {
+    let originalTestAssertionsString = "then\n  fileExists \"README.md\""
+
+    let testAssertionsString = project.files().reduce(function(acc, file) {
+      if (notACommonPeripheralArtifact(file)) {
+          if(acc === "then") {
+            acc +=  "\n  ";
+          } else {
+            acc +=  "\n    and ";
+          }
+          acc += `fileExists \"{file.path()}\"`;
+      }
+      return acc;
+    },"then")
+
+    let eng: PathExpressionEngine = project.context().pathExpressionEngine();
+    let testPathExpression = new PathExpression<Project, File>("/*[@name='.atomist']/tests/*[@name='" + generatorName + ".rt']");
+    let testFile: File = eng.scalar(project, testPathExpression);
+    testFile.replace(originalTestAssertionsString, testAssertionsString)
+}
+
+function notACommonPeripheralArtifact(file: File): boolean {
+    return (file.path().search("node_modules") < 0) &&
+           (file.path().search(".idea") < 0) && 
+           (file.path().search("target") < 0) &&
+           (file.path().search(".atomist") < 0)
+}

--- a/.atomist/tests/ConvertExistingProjectToGenerator.rt
+++ b/.atomist/tests/ConvertExistingProjectToGenerator.rt
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+scenario ConvertExistingProjectToGenerator should add Rug archive files and default generator
+
+let archive_name = "my-rug-archive"
+let group_id = "my-rug-group"
+let version = "0.0.1"
+let manifest = ".atomist/manifest.yml"
+let generator_name = "MyNewGenerator"
+let description = "Description of MyNewGenerator"
+
+given
+  Empty
+
+when
+  ConvertExistingProjectToGenerator
+
+then
+  fileExists manifest
+    and fileContains manifest { 'artifact: "' + archive_name + '"' }
+    and fileContains manifest { 'group: "' + group_id + '"' }
+    and fileContains manifest version
+    and fileExists ".atomist/package.json"
+    and fileContains ".atomist/package.json" '"@atomist/rug"'
+    and fileContains ".atomist/package.json" '"0.12.0"'
+    and fileExists ".atomist/tsconfig.json"
+    and fileContains ".atomist/tsconfig.json" "suppressImplicitAnyIndexErrors"
+    and fileExists ".atomist/.gitignore"
+    and fileContains ".atomist/.gitignore" "node_modules"
+    and directoryExists ".atomist/node_modules/@atomist/rug"
+    and fileExists ".atomist/node_modules/@atomist/rug/model/Core.ts"
+    and fileExists ".atomist/editors/MyNewGenerator.ts"
+    and fileContains ".atomist/editors/MyNewGenerator.ts" '@Generator("MyNewGenerator"'
+    and fileContains ".atomist/editors/MyNewGenerator.ts" "class MyNewGenerator"
+    and fileContains ".atomist/editors/MyNewGenerator.ts" "new MyNewGenerator()"
+    and { !result.fileContains(".atomist/editors/MyNewGenerator.ts", "TypeScriptGenerator") }
+    and { !result.fileContains(".atomist/editors/MyNewGenerator.ts", "@DESCRIPTION@") }
+    and { !result.fileContains(".atomist/editors/MyNewGenerator.ts", "typeScriptGenerator") }
+    and fileExists ".atomist/tests/MyNewGenerator.rt"
+    and fileContains ".atomist/tests/MyNewGenerator.rt" "scenario MyNewGenerator"
+    and { !result.fileContains(".atomist/tests/MyNewGenerator.rt", "TypeScriptGenerator") }
+
+
+scenario ConvertExistingProjectToGenerator should make no change if project already contains a manifest
+
+let archive_name = "my-rug-archive"
+let group_id = "my-rug-group"
+let version = "0.0.1"
+let generator_name = "MyNewGenerator"
+let description = "Description of MyNewGenerator"
+
+given
+  ArchiveRoot
+
+when
+  ConvertExistingProjectToGenerator
+
+then
+  NoChange

--- a/.atomist/tests/ConvertExistingProjectToGenerator.rt
+++ b/.atomist/tests/ConvertExistingProjectToGenerator.rt
@@ -55,6 +55,54 @@ then
     and { !result.fileContains(".atomist/tests/MyNewGenerator.rt", "TypeScriptGenerator") }
 
 
+scenario ConvertExistingProjectToGenerator should add appropriate generator tests assertions
+
+let archive_name = "my-rug-archive"
+let group_id = "my-rug-group"
+let version = "0.0.1"
+let manifest = ".atomist/manifest.yml"
+let generator_name = "MyNewGenerator"
+let description = "Description of MyNewGenerator"
+
+given
+  "README.md" = "Beulah"
+  "CHANGELOG.md" = "Handsome Western States"
+  "LICENSE" = "When Your Heartstrings Break"
+  "configure" = "The Coast Is Never Clear"
+
+when
+  ConvertExistingProjectToGenerator
+
+then
+  fileExists manifest
+    and fileContains manifest { 'artifact: "' + archive_name + '"' }
+    and fileContains manifest { 'group: "' + group_id + '"' }
+    and fileContains manifest version
+    and fileExists ".atomist/package.json"
+    and fileContains ".atomist/package.json" '"@atomist/rug"'
+    and fileContains ".atomist/package.json" '"0.12.0"'
+    and fileExists ".atomist/tsconfig.json"
+    and fileContains ".atomist/tsconfig.json" "suppressImplicitAnyIndexErrors"
+    and fileExists ".atomist/.gitignore"
+    and fileContains ".atomist/.gitignore" "node_modules"
+    and directoryExists ".atomist/node_modules/@atomist/rug"
+    and fileExists ".atomist/node_modules/@atomist/rug/model/Core.ts"
+    and fileExists ".atomist/editors/MyNewGenerator.ts"
+    and fileContains ".atomist/editors/MyNewGenerator.ts" '@Generator("MyNewGenerator"'
+    and fileContains ".atomist/editors/MyNewGenerator.ts" "class MyNewGenerator"
+    and fileContains ".atomist/editors/MyNewGenerator.ts" "new MyNewGenerator()"
+    and { !result.fileContains(".atomist/editors/MyNewGenerator.ts", "TypeScriptGenerator") }
+    and { !result.fileContains(".atomist/editors/MyNewGenerator.ts", "@DESCRIPTION@") }
+    and { !result.fileContains(".atomist/editors/MyNewGenerator.ts", "typeScriptGenerator") }
+    and fileExists ".atomist/tests/MyNewGenerator.rt"
+    and fileContains ".atomist/tests/MyNewGenerator.rt" "scenario MyNewGenerator"
+    and { !result.fileContains(".atomist/tests/MyNewGenerator.rt", "TypeScriptGenerator") }
+    and fileContains ".atomist/tests/MyNewGenerator.rt" 'fileExists "README.md"'
+    and fileContains ".atomist/tests/MyNewGenerator.rt" 'fileExists "CHANGELOG.md"'
+    and fileContains ".atomist/tests/MyNewGenerator.rt" 'fileExists "LICENSE"'
+    and fileContains ".atomist/tests/MyNewGenerator.rt" 'fileExists "configure"'
+
+
 scenario ConvertExistingProjectToGenerator should make no change if project already contains a manifest
 
 let archive_name = "my-rug-archive"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/atomist-rugs/rug-editors/compare/0.12.0...HEAD
+[Unreleased]: https://github.com/atomist-rugs/rug-editors/compare/0.13.0...HEAD
+
+## [0.13.0] - 2017-03-03
+
+[0.13.0]: https://github.com/atomist-rugs/rug-editors/compare/0.12.0...0.13.0
+
+One-step generator release
+
+### Added
+
+-   `ConvertExistingProjectToGenerator` editor
 
 ## [0.12.0] - 2017-03-01
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,52 @@ $ rug edit atomist-rugs:rug-editors:AddTypeScriptHandler \
 This will add the file `.atomist/handlers/MyNewHandler.ts` to the
 project.
 
+### ConvertExistingProjectToGenerator
+
+The ConvertExistingProjectToGenerator editor creates a valid Rug
+generator from the current project.  It does not make sense to run
+this more than once on a project.
+
+#### Prerequisites
+
+Before running this editor, you must have the following prerequisites
+satisfied.
+
+*   A source code repository for a "model" project that does not have
+    a `.atomist/manifest.yml`
+
+#### Parameters
+
+To run this editor, you must supply the following parameters.
+
+Name | Required | Default | Description
+-----|----------|---------|------------
+`archive_name` | Yes | | Name of the new Rug archive, typically the same as the repo name
+`group_id` | Yes | | Maven group ID, e.g., "company-rugs", typically the GitHub owner of the repo
+`version` | No | 0.1.0 | [Semantic version][semver] of the project.
+`generator_name` | Yes | | A valid Rug generator name between 1-100 characters, starting with a capital letter, and containing only alphanumeric characters
+`description` | Yes | | A description of the generator being added
+
+#### Running
+
+Run it as follows:
+
+```
+$ cd project/directory
+$ rug edit atomist-rugs:rug-editors:ConvertExistingProjectToGenerator \
+    archive_name=my-new-archive \
+    group_id=my-rugs \
+    version=2.71.828 \
+    generator_name=MyNewGenerator \
+    description="This is my newest generator."
+```
+
+This will create a `.atomist` directory to the root of the project.
+The `.atomist` directory will have valid `manifest.yml` and
+`package.json` files, the generator script in
+`editors/MyNewGenerator.ts`, and its test in
+`tests/MyNewGenerator.rt`.
+
 ### ConvertExistingProjectToRugArchive
 
 The ConvertExistingProjectToRugArchive editor creates a valid Rug


### PR DESCRIPTION
Implementation of editor that will turn an existing project into a generator.

To try it out create any working project and run the `ConvertExistingProjectToGenerator` editor against it.
