### PR TITLE
No longer add node_modules

### DIFF
--- a/.atomist/editors/AddTypeScript.ts
+++ b/.atomist/editors/AddTypeScript.ts
@@ -35,14 +35,10 @@ class AddTypeScript implements EditProject {
             return;
         }
 
-        let packageJsonPath = ".atomist/package.json";
-        let tsconfigJsonPath = ".atomist/tsconfig.json";
-        let gitignorePath = ".atomist/.gitignore";
-        let nodeModulesPath = ".atomist/node_modules";
-        project.copyEditorBackingFileOrFail(packageJsonPath);
-        project.copyEditorBackingFileOrFail(tsconfigJsonPath);
-        project.copyEditorBackingFileOrFail(gitignorePath);
-        project.copyEditorBackingFilesPreservingPath(nodeModulesPath);
+        project.copyEditorBackingFileOrFail(".atomist/package.json");
+        project.copyEditorBackingFileOrFail(".atomist/tsconfig.json");
+        project.copyEditorBackingFileOrFail(".atomist/.gitignore");
+        console.log("TypeScript files added, run `cd .atomist && npm install`");
     }
 }
 

--- a/.atomist/manifest.yml
+++ b/.atomist/manifest.yml
@@ -1,6 +1,6 @@
 group: atomist-rugs
 artifact: rug-editors
-version: "0.13.0"
+version: "0.14.0"
 requires: "[0.12.0,1.0.0)"
 dependencies:
 extensions:

--- a/.atomist/tests/AddTypeScript.rt
+++ b/.atomist/tests/AddTypeScript.rt
@@ -31,8 +31,8 @@ then
     and fileContains ".atomist/tsconfig.json" "suppressImplicitAnyIndexErrors"
     and fileExists ".atomist/.gitignore"
     and fileContains ".atomist/.gitignore" "node_modules"
-    and directoryExists ".atomist/node_modules/@atomist/rug"
-    and fileExists ".atomist/node_modules/@atomist/rug/model/Core.ts"
+    and { !result.directoryExists(".atomist/node_modules/@atomist/rug") }
+    and { !result.fileExists(".atomist/node_modules/@atomist/rug/model/Core.ts") }
 
 
 scenario AddTypeScript should not make any changes if the target project is not a Rug archive

--- a/.atomist/tests/ConvertExistingProjectToGenerator.rt
+++ b/.atomist/tests/ConvertExistingProjectToGenerator.rt
@@ -41,8 +41,8 @@ then
     and fileContains ".atomist/tsconfig.json" "suppressImplicitAnyIndexErrors"
     and fileExists ".atomist/.gitignore"
     and fileContains ".atomist/.gitignore" "node_modules"
-    and directoryExists ".atomist/node_modules/@atomist/rug"
-    and fileExists ".atomist/node_modules/@atomist/rug/model/Core.ts"
+    and { !result.directoryExists(".atomist/node_modules/@atomist/rug") }
+    and { !result.fileExists(".atomist/node_modules/@atomist/rug/model/Core.ts") }
     and fileExists ".atomist/editors/MyNewGenerator.ts"
     and fileContains ".atomist/editors/MyNewGenerator.ts" '@Generator("MyNewGenerator"'
     and fileContains ".atomist/editors/MyNewGenerator.ts" "class MyNewGenerator"
@@ -85,8 +85,8 @@ then
     and fileContains ".atomist/tsconfig.json" "suppressImplicitAnyIndexErrors"
     and fileExists ".atomist/.gitignore"
     and fileContains ".atomist/.gitignore" "node_modules"
-    and directoryExists ".atomist/node_modules/@atomist/rug"
-    and fileExists ".atomist/node_modules/@atomist/rug/model/Core.ts"
+    and { !result.directoryExists(".atomist/node_modules/@atomist/rug") }
+    and { !result.fileExists(".atomist/node_modules/@atomist/rug/model/Core.ts") }
     and fileExists ".atomist/editors/MyNewGenerator.ts"
     and fileContains ".atomist/editors/MyNewGenerator.ts" '@Generator("MyNewGenerator"'
     and fileContains ".atomist/editors/MyNewGenerator.ts" "class MyNewGenerator"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Have editors that add TypeScript Rugs add the TypeScript support
     files if they are not present
 
+-   AddTypeScript and ConvertExistingProjectToGenerator no longer add
+    the node_modules directory
+
 ### Removed
 
 -   UpdateRugVersion has been moved to rug-upgrade

--- a/README.md
+++ b/README.md
@@ -74,8 +74,14 @@ $ rug edit atomist-rugs:rug-editors:AddTypeScript
 ```
 
 This will add `package.json`, `tsconfig.json`, and `.gitignore` files
-and the `node_modules` directory to the `.atomist` directory in the
-project.
+to the `.atomist` directory in the project.  You will need to install
+the [node][] dependencies using NPM.
+
+```
+$ ( cd .atomist && npm install )
+```
+
+[node]: https://nodejs.org/
 
 ### AddTypeScriptEditor
 
@@ -260,10 +266,14 @@ $ rug edit atomist-rugs:rug-editors:ConvertExistingProjectToGenerator \
 ```
 
 This will create a `.atomist` directory to the root of the project.
-The `.atomist` directory will have valid `manifest.yml` and
-`package.json` files, the generator script in
-`editors/MyNewGenerator.ts`, and its test in
-`tests/MyNewGenerator.rt`.
+The `.atomist` directory will have valid `manifest.yml` and TypeScript
+files, the generator script in `editors/MyNewGenerator.ts`, and its
+test in `tests/MyNewGenerator.rt`.  You will need to install
+the [node][] dependencies using NPM.
+
+```
+$ ( cd .atomist && npm install )
+```
 
 ### ConvertExistingProjectToRugArchive
 


### PR DESCRIPTION
AddTypeScript and ConvertExistingProjectToGenerator no longer add the
node_modules when adding TypeScript files.

Closes #30